### PR TITLE
feat: add debug cmds (listjobs) + minimal gating infra

### DIFF
--- a/.github/workflows/publish_production.yml
+++ b/.github/workflows/publish_production.yml
@@ -79,6 +79,8 @@ jobs:
             echo POSTGRES_URL=${{ env.POSTGRES_URL }} >> .env
             echo TELEGRAM_TOKEN=${{ env.TELEGRAM_TOKEN }} >> .env
             echo TELEGRAM_ERROR_CHAT_ID=${{ env.TELEGRAM_ERROR_CHAT_ID }} >> .env
+            echo DEBUG=False >> .env
+            echo TEAM_TELEGRAM_IDS=${{ secrets.TEAM_TELEGRAM_IDS }} >> .env
             docker-compose -f docker-compose.${{ env.PACKAGE_LABEL }}.yml stop
             docker-compose -f docker-compose.${{ env.PACKAGE_LABEL }}.yml pull
             docker-compose -f docker-compose.${{ env.PACKAGE_LABEL }}.yml up --force-recreate -d

--- a/.github/workflows/publish_testing.yml
+++ b/.github/workflows/publish_testing.yml
@@ -79,6 +79,8 @@ jobs:
             echo POSTGRES_URL=${{ env.POSTGRES_URL }} >> .env
             echo TELEGRAM_TOKEN=${{ env.TELEGRAM_TOKEN }} >> .env
             echo TELEGRAM_ERROR_CHAT_ID=${{ env.TELEGRAM_ERROR_CHAT_ID }} >> .env
+            echo DEBUG=False >> .env
+            echo TEAM_TELEGRAM_IDS=${{ secrets.TEAM_TELEGRAM_IDS }} >> .env
             docker-compose -f docker-compose.${{ env.PACKAGE_LABEL }}.yml stop
             docker-compose -f docker-compose.${{ env.PACKAGE_LABEL }}.yml pull
             docker-compose -f docker-compose.${{ env.PACKAGE_LABEL }}.yml up --force-recreate -d

--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ def main():
     dp = updater.dispatcher
 
     dp.add_handler(CommandHandler("help", handlers.help_handler))
+    dp.add_handler(CommandHandler("listjobs", handlers.list_jobs_handler))
 
     # group UX
     dp.add_handler(

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,5 @@
 from enum import IntEnum, auto
+import json, os
 
 # MESSAGES
 on_set_new_message = "Обновил сообщение."
@@ -98,3 +99,6 @@ RH_kick_messages = [
 ]
 
 RH_CHAT_ID = -1001147286684
+
+DEBUG = os.environ.get("DEBUG", True)
+TEAM_TELEGRAM_IDS = json.loads(os.environ.get("TEAM_TELEGRAM_IDS", "[]"))

--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -6,4 +6,5 @@ from .help_handler import help_handler
 from .error_handler import error_handler
 
 from .admin import *
+from .debug import *
 from .group import *

--- a/src/handlers/admin/start_handler.py
+++ b/src/handlers/admin/start_handler.py
@@ -2,8 +2,9 @@ from telegram import InlineKeyboardMarkup, Update
 from telegram.ext import CallbackContext
 
 from src import constants
+from src.handlers.utils import admin
 
-from .utils import get_chats_list, create_chats_list_keyboard, admin
+from .utils import get_chats_list, create_chats_list_keyboard
 
 
 @admin

--- a/src/handlers/admin/utils.py
+++ b/src/handlers/admin/utils.py
@@ -1,6 +1,5 @@
 import json
 from typing import Iterator, Dict, List
-from functools import wraps
 
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import CallbackContext
@@ -129,27 +128,6 @@ def create_chats_list_keyboard(
         for chat in user_chats
         if authorize_user(context.bot, chat["id"], user_id)
     ]
-
-
-def admin(func):
-    """
-    A decorator to ensure that a particular function is only executed in private chats,
-    and not in group chats.
-
-    Args:
-    func (Callable): The function to be wrapped by the decorator.
-
-    Returns:
-    Callable: The wrapper function which includes the functionality for checking the chat type.
-    """
-
-    @wraps(func)
-    def wrapper(update: Update, context: CallbackContext, *args, **kwargs):
-        if update.message.chat_id < 0:
-            return  # Skip the execution of the function in case of group chat
-        return func(update, context, *args, **kwargs)
-
-    return wrapper
 
 
 def get_chat_name(bot: Bot, chat_id: int):

--- a/src/handlers/debug/__init__.py
+++ b/src/handlers/debug/__init__.py
@@ -1,0 +1,5 @@
+"""
+Module with all the telegram handlers used for debugging.
+"""
+
+from .list_jobs_handler import list_jobs_handler

--- a/src/handlers/debug/list_jobs_handler.py
+++ b/src/handlers/debug/list_jobs_handler.py
@@ -1,4 +1,5 @@
-from telegram import InlineKeyboardMarkup, Update
+import html
+from telegram import ParseMode, Update
 from telegram.ext import CallbackContext
 
 from src import constants
@@ -7,7 +8,13 @@ from src.handlers.utils import debug
 
 @debug
 def list_jobs_handler(update: Update, context: CallbackContext) -> None:
-    update.message.reply_text(f"Jobs: {len(context.job_queue.jobs())} items\n\n" + "\n".join([
-        f"Job {job.name}\n Context: {job.context}"
-        for job in context.job_queue.jobs()
-    ]))
+    update.message.reply_text(
+        f"<b>Jobs: {len(context.job_queue.jobs())} items</b>\n\n"
+        + "\n\n".join(
+            [
+                f"Job <i>{html.escape(job.name)}</i> ts {html.escape(str(job.next_t)) if job.next_t else 'None'}\nContext: <code>{html.escape(str(job.context))}</code>"
+                for job in context.job_queue.jobs()
+            ]
+        ),
+        parse_mode=ParseMode.HTML,
+    )

--- a/src/handlers/debug/list_jobs_handler.py
+++ b/src/handlers/debug/list_jobs_handler.py
@@ -1,0 +1,13 @@
+from telegram import InlineKeyboardMarkup, Update
+from telegram.ext import CallbackContext
+
+from src import constants
+from src.handlers.utils import debug
+
+
+@debug
+def list_jobs_handler(update: Update, context: CallbackContext) -> None:
+    update.message.reply_text(f"Jobs: {len(context.job_queue.jobs())} items\n\n" + "\n".join([
+        f"Job {job.name}\n Context: {job.context}"
+        for job in context.job_queue.jobs()
+    ]))

--- a/src/handlers/utils.py
+++ b/src/handlers/utils.py
@@ -1,0 +1,45 @@
+from functools import wraps
+
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from src.constants import DEBUG, TEAM_TELEGRAM_IDS
+
+
+def admin(func):
+    """
+    A decorator to ensure that a particular function is only executed in private chats,
+    and not in group chats.
+
+    Args:
+    func (Callable): The function to be wrapped by the decorator.
+
+    Returns:
+    Callable: The wrapper function which includes the functionality for checking the chat type.
+    """
+
+    @wraps(func)
+    def wrapper(update: Update, context: CallbackContext, *args, **kwargs):
+        if update.message.chat_id < 0:
+            return  # Skip the execution of the function in case of group chat
+        return func(update, context, *args, **kwargs)
+
+    return wrapper
+
+def debug(func):
+    """
+    A decorator to ensure that a particular function is only executed for debug purposes, i.e. by someone from the team.
+
+    Args:
+    func (Callable): The function to be wrapped by the decorator.
+
+    Returns:
+    Callable: The wrapper function which includes the functionality for checking the called ID.
+    """
+
+    @wraps(func)
+    def wrapper(update: Update, context: CallbackContext, *args, **kwargs):
+        if DEBUG or update.message.chat_id in TEAM_TELEGRAM_IDS:
+            return func(update, context, *args, **kwargs)
+
+    return wrapper

--- a/src/handlers/utils.py
+++ b/src/handlers/utils.py
@@ -26,6 +26,7 @@ def admin(func):
 
     return wrapper
 
+
 def debug(func):
     """
     A decorator to ensure that a particular function is only executed for debug purposes, i.e. by someone from the team.


### PR DESCRIPTION
![image](https://github.com/alexeyqu/wachter_bot/assets/7394728/dac195fa-81e9-4271-a910-bcd997d44b9f)

Gating is done via 2 env vars: 
- `DEBUG` a bool which overrides any gate, `False` in deployed code, `True` by default;
- `TEAM_TELEGRAM_IDS`: json list of Telegram IDs of allowed users.